### PR TITLE
Added includeOnly for complex folder structures, updated tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ const config = {
     },
     test: {
       filetypes: ['.js', '.json'],
+      includeOnly: /test/,
       path: './example/react/test/'
     }
   },
@@ -138,6 +139,7 @@ module.exports = config;
 |-------------|----------|----------|----------|-------------|
 | `exclude`    | no      | regex | none| Regex to exclude matching files or folders |
 | `filetypes`    | no      | array | includes all files |An array of filetypes to include `[".js",".handlebars",".json"]`. Although this is not required, it is better to include file types so that `.DS_Store` and other hidden files are not included. |
+| `includeOnly`    | no      | regex | none| Includes only files and folders matching this regex. Useful for complex folder structures. |
 | `path`    | yes      | string | none| Path to the src or test directory |
 
 

--- a/example/stats-example.conf.js
+++ b/example/stats-example.conf.js
@@ -9,7 +9,8 @@ const config = {
     },
     test: {
       filetypes: ['.js', '.handlebars', '.json'],
-      path: './example/tests/'
+      path: './example/tests/',
+      includeOnly: /overview/
     }
   },
   framework2: {

--- a/example/tests/index.js
+++ b/example/tests/index.js
@@ -1,184 +1,28 @@
-describe('App.Routers.Router', function() {
-  // Default option: Trigger and replace history.
-  var opts = { trigger: true, replace: true };
+//Some index source
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
 
-  // Routing tests are a bit complicated in that the actual hash
-  // fragment can change unless fully mocked out. We *do not* mock
-  // the URL mutations meaning that a hash fragment will appear in
-  // our test run (making the test driver appear to be a single
-  // page app).
-  //
-  // There are alternative approaches to this, such as Backbone.js'
-  // own unit tests which fully fake out the URL browser location
-  // with a mocked object to instead contain URL information and
-  // behave mostly like a real location.
-  before(function() {
-    // Dependencies and fake patches.
-    this.sandbox = sinon.sandbox.create();
+module.exports = moduleName => {
+  const RealComponent = require.requireActual(moduleName);
+  const React = require('react');
 
-    // Mock the entire `Notes` object.
-    this.sandbox.mock(App.Views.Notes);
+  const Component = class extends RealComponent {
+    render() {
+      const name = RealComponent.displayName || RealComponent.name;
 
-    // Stub `Note` prototype and configure `render`.
-    this.sandbox.stub(App.Views.Note.prototype);
-    App.Views.Note.prototype.render.returns({ $el: null });
-  });
-
-  beforeEach(function() {
-    // Fake function: Get a model simulation if id is "1".
-    var get1 = function(i) {
-      return i === '1' ? { id: '1' } : null;
-    };
-
-    // Create router with stubs and manual fakes.
-    this.router = new App.Routers.Router({
-      notesView: {
-        render: this.sandbox.stub(),
-        collection: { get: get1 }
-      },
-      noteNavView: this.sandbox.stub()
-    });
-
-    // Start history to enable routes to fire.
-    Backbone.history.start();
-
-    // Spy on all route events.
-    this.routerSpy = sinon.spy();
-    this.router.on('route', this.routerSpy);
-  });
-
-  afterEach(function() {
-    // Navigate to home page and stop history.
-    this.router.navigate('', opts);
-    Backbone.history.stop();
-  });
-
-  after(function() {
-    this.sandbox.restore();
-  });
-
-  describe('routing', function() {
-    before(function() {
-      // Stub out notes and note to check routing.
-      //
-      // Happens **before** the router instantiation.
-      // If we stub *after* instantiation, then `notes` and `note`
-      // can no longer be stubbed in the usual manner.
-      sinon.stub(App.Routers.Router.prototype, 'notes');
-      sinon.stub(App.Routers.Router.prototype, 'note');
-    });
-
-    beforeEach(function() {
-      // Reset before every run.
-      App.Routers.Router.prototype.notes.reset();
-      App.Routers.Router.prototype.note.reset();
-    });
-
-    after(function() {
-      App.Routers.Router.prototype.notes.restore();
-      App.Routers.Router.prototype.note.restore();
-    });
-
-    it('can route to notes', function() {
-      // Start out at other route and navigate home.
-      this.router.navigate('note/1/edit', opts);
-      this.router.navigate('', opts);
-      expect(
-        App.Routers.Router.prototype.notes
-      ).to.have.been.calledOnce.and// Updated for Backbone.js v1.1.2. Was:
-      // .to.have.been.calledWithExactly();
-      .to.have.been.calledWithExactly(null);
-    });
-
-    it('can route to note', function() {
-      this.router.navigate('note/1/edit', opts);
-      expect(
-        App.Routers.Router.prototype.note
-      ).to.have.been.calledOnce.and// Updated for Backbone.js v1.1.2. Was:
-      // .to.have.been.calledWithExactly("1", "edit");
-      .to.have.been.calledWithExactly('1', 'edit', null);
-    });
-  });
-
-  describe('notes', function() {
-    it('can navigate to notes page', function() {
-      // Start out at other route and navigate home.
-      this.router.navigate('note/1/edit', opts);
-      this.router.navigate('', opts);
-
-      // Spy has now been called **twice**.
-      expect(
-        this.routerSpy
-      ).to.have.been.calledTwice.and.to.have.been.calledWith('notes');
-    });
-  });
-
-  describe('note', function() {
-    it(
-      'can navigate to note page',
-      sinon.test(function() {
-        this.router.navigate('note/1/edit', opts);
-
-        expect(
-          this.routerSpy
-        ).to.have.been.calledOnce.and// Updated for Backbone.js v1.1.2. Was:
-        // .to.have.been.calledWith("note", ["1", "edit"]);
-        .to.have.been.calledWith('note', ['1', 'edit', null]);
-      })
-    );
-
-    it(
-      'can navigate to same note',
-      sinon.test(function() {
-        // Short router: Skip test if empty router.
-        if (!this.router.noteView) {
-          return;
-        }
-
-        this.router.navigate('note/1/edit', opts);
-        expect(
-          this.routerSpy
-        ).to.have.been.calledOnce.and// Updated for Backbone.js v1.1.2. Was:
-        // .to.have.been.calledWith("note", ["1", "edit"]);
-        .to.have.been.calledWith('note', ['1', 'edit', null]);
-
-        // Manually patch in model property (b/c stubbed).
-        this.router.noteView.model = { id: '1' };
-
-        // Navigating to same with different action works.
-        this.router.navigate('note/1/view', opts);
-        expect(
-          this.routerSpy
-        ).to.have.been.calledTwice.and// Updated for Backbone.js v1.1.2. Was:
-        // .to.have.been.calledWith("note", ["1", "view"]);
-        .to.have.been.calledWith('note', ['1', 'view', null]);
-
-        // Even with error, should still `remove` existing.
-        this.router.navigate('note/2/view', opts);
-        expect(this.router.noteView.remove).to.have.been.calledOnce;
-      })
-    );
-
-    it(
-      'navigates to list on no model',
-      sinon.test(function() {
-        // Short router: Skip test if empty router.
-        if (!this.router.noteView) {
-          return;
-        }
-
-        this.router.navigate('note/2/edit', opts);
-
-        // Note that the route events are out of order because
-        // the re-navigation to "notes" happens **first**.
-        expect(
-          this.routerSpy
-        ).to.have.been.calledTwice.and// Updated for Backbone.js v1.1.2. Was:
-        // .to.have.been.calledWith("note", ["2", "edit"]).and
-        .to.have.been
-          .calledWith('note', ['2', 'edit', null])
-          .and.to.have.been.calledWith('notes');
-      })
-    );
-  });
-});
+      return React.createElement(
+        name.replace(/^(RCT|RK)/, ''),
+        this.props,
+        this.props.children
+      );
+    }
+  };
+  return Component;
+};

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "clean": "rm -rf .jest node_modules",
     "cover": "jest --coverage",
     "demo": "yarn build && node ./lib/stats --config='../example/stats-example.conf.js'",
-    "dev": "watch 'yarn build;yarn demo' ./src",
+    "dev": "watch 'yarn build;yarn demo' ./src ./example",
     "dev-test": "watch 'yarn build;yarn test' ./src ./test",
     "format": "eslint --fix ./src/stats.js ./src/stats-constants.json ./src/utils/helpers.js",
     "lint": "eslint ./src/stats.js ./src/stats-constants.json ./src/utils/helpers.js",

--- a/src/stats-constants.js
+++ b/src/stats-constants.js
@@ -14,6 +14,7 @@ const constants = {
     FILETYPES: 'filetypes',
     FRAMEWORK1: 'framework1',
     FRAMEWORK2: 'framework2',
+    INCLUDE_ONLY: 'includeOnly',
     NAME: 'name',
     OPTIONS: 'options',
     OPTIONS_KEYS: {

--- a/src/stats.js
+++ b/src/stats.js
@@ -139,6 +139,9 @@ Object.keys(config).forEach(frameworkNumber => {
         let excludeRegExp =
           config[frameworkNumber][typeOfCode][CONFIG_KEYS.EXCLUDE];
 
+        // Get regex for include
+        let includeOnlyRegExp =
+          config[frameworkNumber][typeOfCode][CONFIG_KEYS.INCLUDE_ONLY];
         // Get the tree and count the total numbe of files
         // This increments the stats for the current FW and
         // its type i.e src or test
@@ -150,6 +153,14 @@ Object.keys(config).forEach(frameworkNumber => {
             if (excludeRegExp && excludeRegExp.test(item[COMMON_KEYS.PATH])) {
               return;
             }
+            // If this path does not matches the include regex then return
+            if (
+              includeOnlyRegExp &&
+              !includeOnlyRegExp.test(item[COMMON_KEYS.PATH])
+            ) {
+              return;
+            }
+
             stats[framework][type]++;
           }
         );
@@ -176,6 +187,15 @@ Object.keys(config).forEach(frameworkNumber => {
           if (excludeRegExp && excludeRegExp.test(file[COMMON_KEYS.PATH])) {
             return;
           }
+
+          // If this path does not matches the include regex then return
+          if (
+            includeOnlyRegExp &&
+            !includeOnlyRegExp.test(file[COMMON_KEYS.PATH])
+          ) {
+            return;
+          }
+
           let code = fs.readFileSync(file[COMMON_KEYS.PATH], 'utf8', function(
             err
           ) {

--- a/test/stats-test.conf.js
+++ b/test/stats-test.conf.js
@@ -9,7 +9,8 @@ const config = {
     },
     test: {
       filetypes: ['.js', '.handlebars', '.json'],
-      path: './example/tests/'
+      path: './example/tests/',
+      includeOnly: /overview/
     }
   },
   framework2: {

--- a/test/test.js
+++ b/test/test.js
@@ -27,8 +27,8 @@ describe('Stats tests', function() {
       });
     });
     describe('Backbone test files', function() {
-      it('It should have 3 backbone test files', function() {
-        assert.equal(3, output[CONFIG_KEYS.FRAMEWORK1][STATS_KEYS.TEST_FILES]);
+      it('It should have 2 backbone test files', function() {
+        assert.equal(2, output[CONFIG_KEYS.FRAMEWORK1][STATS_KEYS.TEST_FILES]);
       });
     });
     describe('React test files', function() {
@@ -80,17 +80,17 @@ describe('Stats tests', function() {
 
   describe('File percentage should be correct', function() {
     describe('Backbone percentage', function() {
-      it('It should be 53 percent', function() {
+      it('It should be 50 percent', function() {
         assert.equal(
-          53,
+          50,
           output[CONFIG_KEYS.FRAMEWORK1][STATS_KEYS.PERCENTAGE_FILES]
         );
       });
     });
     describe('React percentage', function() {
-      it('It should be 47 percent', function() {
+      it('It should be 50 percent', function() {
         assert.equal(
-          47,
+          50,
           output[CONFIG_KEYS.FRAMEWORK2][STATS_KEYS.PERCENTAGE_FILES]
         );
       });
@@ -116,13 +116,13 @@ describe('Stats tests', function() {
         );
         assert.deepEqual(
           {
-            total: 317,
-            source: 208,
-            comment: 64,
-            single: 64,
+            total: 133,
+            source: 91,
+            comment: 17,
+            single: 17,
             block: 0,
-            mixed: 6,
-            empty: 51,
+            mixed: 0,
+            empty: 25,
             todo: 0
           },
           output[CONFIG_KEYS.FRAMEWORK1][STATS_KEYS.TEST_LOC]
@@ -163,9 +163,9 @@ describe('Stats tests', function() {
 
   describe('LOC percentage should be correct', function() {
     describe('Backbone percentage', function() {
-      it('It should be 40 percent', function() {
+      it('It should be 29 percent', function() {
         assert.equal(
-          40,
+          29,
           output[CONFIG_KEYS.FRAMEWORK1][STATS_KEYS.PERCENTAGE_LOC]
         );
       });
@@ -173,7 +173,7 @@ describe('Stats tests', function() {
     describe('React percentage', function() {
       it('It should be 60 percent', function() {
         assert.equal(
-          60,
+          71,
           output[CONFIG_KEYS.FRAMEWORK2][STATS_KEYS.PERCENTAGE_LOC]
         );
       });


### PR DESCRIPTION
This PR adds the ability to include only a particular set of files/folders. The combination of exclude and include makes any sensible structure traversable. 