### PR TITLE
We don't need the conf in lib

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,3 +5,4 @@
 /out/
 /src/
 /test/
+stats.conf.js


### PR DESCRIPTION
This removes the stats.conf.js from lib on the package.